### PR TITLE
Signer access through config

### DIFF
--- a/Sources/JWTProvider/Config+JWT.swift
+++ b/Sources/JWTProvider/Config+JWT.swift
@@ -1,0 +1,21 @@
+import JWT
+import Vapor
+
+private let jwtSignerKey = "jwt-provider:signer"
+
+extension Config {
+    public internal(set) var signer: Signer? {
+        get { return storage[jwtSignerKey] as? Signer }
+        set { storage[jwtSignerKey] = newValue }
+    }
+
+    /// Returns the main JWT signer
+    /// or throws an error if not properly configured
+    public func assertSigner() throws -> Signer {
+        guard let signer = self.signer else {
+            throw JWTProviderError.noJWTSigner
+        }
+
+        return signer
+    }
+}

--- a/Sources/JWTProvider/Droplet+JWT.swift
+++ b/Sources/JWTProvider/Droplet+JWT.swift
@@ -1,21 +1,15 @@
-import Vapor
 import JWT
-
-private let jwtSignerKey = "jwt-provider:signer"
+import Vapor
 
 extension Droplet {
     public internal(set) var signer: Signer? {
-        get { return storage[jwtSignerKey] as? Signer }
-        set { storage[jwtSignerKey] = newValue }
+        get { return config.signer }
+        set { config.signer = newValue }
     }
-    
+
     /// Returns the main JWT signer
     /// or throws an error if not properly configured
     public func assertSigner() throws -> Signer {
-        guard let signer = self.signer else {
-            throw JWTProviderError.noJWTSigner
-        }
-
-        return signer
+        return try config.assertSigner()
     }
 }

--- a/Sources/JWTProvider/Provider.swift
+++ b/Sources/JWTProvider/Provider.swift
@@ -99,26 +99,13 @@ public final class Provider: Vapor.Provider {
         }
 
         self.init(signer: signer)
-        config.signer = signer
     }
     
-    public func boot(_ config: Config) throws { }
-
-    /// Called to prepare the Droplet.
-    public func boot(_ drop: Droplet) {
-
+    public func boot(_ config: Config) throws {
+        config.signer = signer
     }
 
-    /// Called after the Droplet has completed
-    /// initialization and all provided items
-    /// have been accepted.
-    public func afterInit(_ drop: Droplet) {
+    public func boot(_ drop: Droplet) throws {}
 
-    }
-
-    /// Called before the Droplet begins serving
-    /// which is @noreturn.
-    public func beforeRun(_ drop: Droplet) {
-
-    }
+    public func beforeRun(_ drop: Droplet) throws {}
 }

--- a/Sources/JWTProvider/Provider.swift
+++ b/Sources/JWTProvider/Provider.swift
@@ -99,13 +99,14 @@ public final class Provider: Vapor.Provider {
         }
 
         self.init(signer: signer)
+        config.signer = signer
     }
     
     public func boot(_ config: Config) throws { }
 
     /// Called to prepare the Droplet.
     public func boot(_ drop: Droplet) {
-        drop.signer = signer
+
     }
 
     /// Called after the Droplet has completed


### PR DESCRIPTION
I ran into the situation where I'd like to have the signer be available through the Config instead of the Droplet when creating a Configinitializable Command. This PR moves the actual storage of the signer to Config but still allows access through the Droplet as well.